### PR TITLE
feat: initial implementation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-* @bajtos
+* @bajtos @juliangruber @pyropy @NikolasHaimerl
 */package.json
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ Error properties:
 
 - `npm test` to run the tests.
 - `npm run lint:fix` to fix linting issues.
-- `npx np` to publish a new version
+- `npx np` to publish a new version.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,37 @@
 # assert-ok-response
 
 A tiny helper to assert that response from `fetch()` is ok.
+
+## Usage
+
+```js
+import { assertOkResponse } from 'assert-ok-response'
+
+const response = await fetch('https://example.com/not-found')
+await assertOkResponse(response)
+//
+// Throws:
+//
+//  const err = new Error(`${errorMsg ?? `Cannot fetch ${res.url}`} (${res.status}): ${body}`)
+//                ^
+//
+//  Error: Cannot fetch https://example.com/not-found (404): <!doctype html>
+//  [...]
+//  at assertOkResponse (file:///Users/bajtos/src/assert-ok-response/index.js:15:15)
+//  at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+//  at async file:///Users/bajtos/src/assert-ok-response/x.js:4:1 {
+//    statusCode: 404,
+//    serverMessage: '<!doctype html>\n' +
+//  [...]
+```
+
+Error properties:
+
+- `statusCode` (number) - The HTTP status code of the response.
+- `serverMessage` (string) - The response body returned by the server.
+
+## Development
+
+- `npm test` to run the tests.
+- `npm run lint:fix` to fix linting issues.
+- `npx np` to publish a new version

--- a/index.js
+++ b/index.js
@@ -1,19 +1,21 @@
 /**
- * @param {string | URL} url
- * @param {object} options
- * @param {string[][] | Record<string, string | ReadonlyArray<string>> | Headers} [options.requestHeaders]
- * @param {typeof fetch} [options.fetchFn] Custom fetch function (useful for testing)
- * @param {console['log']} [options.debugLog] Debug logger
+ * @param {Response} res The Response object returned by a fetch request.
+ * @param {string} [errorMsg] An optional error message to include in the error thrown if the response is not ok.
  */
-export function createJsonRpcClient(url, { requestHeaders, fetchFn } = {}) {
-  fetchFn = fetchFn ?? fetch
+export async function assertOkResponse(res, errorMsg) {
+  if (res.ok) return
 
-  /**
-   * @param {string} method
-   * @param {[unknown]} [params]
-   */
-  const rpc = async (method, params) => {
-    // TODO
+  let body
+  try {
+    body = await res.text()
+  } catch (/** @type {any} */ err) {
+    body = `(Cannot read response body: ${err.message ?? err})`
   }
-  return rpc
+  body = body?.trimEnd()
+  const err = new Error(`${errorMsg ?? `Cannot fetch ${res.url}`} (${res.status}): ${body}`)
+  Object.assign(err, {
+    statusCode: res.status,
+    serverMessage: body,
+  })
+  throw err
 }

--- a/test.js
+++ b/test.js
@@ -1,10 +1,85 @@
 import { describe, it } from 'node:test'
-import assert from 'node:assert'
-import { createJsonRpcClient } from './index.js'
+import assert, { AssertionError } from 'node:assert'
+import { assertOkResponse } from './index.js'
 
-describe('assert-ok-response', () => {
-  it('should create a JSON-RPC client', () => {
-    const client = createJsonRpcClient('http://example.com')
-    assert.ok(client)
+describe('assertOkResponse', () => {
+  it('accepts ok (200)', async () => {
+    const response = createFakeResponse({
+      ok: true,
+    })
+
+    await assertOkResponse(response)
+  })
+
+  it('rejects !ok (404)', async () => {
+    const response = createFakeResponse({
+      ok: false,
+      status: 404,
+      async text() {
+        return 'endpoint not found'
+      },
+    })
+
+    const error = await assertRejects(() => assertOkResponse(response))
+    assert.equal(error.message, 'Cannot fetch / (404): endpoint not found')
+    assert.equal(error.statusCode, 404)
+    assert.equal(error.serverMessage, 'endpoint not found')
+  })
+
+  it('uses custom message when provided', async () => {
+    const response = createFakeResponse({ ok: false })
+    const error = await assertRejects(() =>
+      assertOkResponse(response, 'Cannot post the measurement'),
+    )
+    assert.match(error.message, /^Cannot post the measurement/)
+  })
+
+  it('handles error while reading error response body', async () => {
+    const response = createFakeResponse({
+      ok: false,
+      status: 500,
+      async text() {
+        throw new Error('chunked encoding error')
+      },
+    })
+
+    const error = await assertRejects(() => assertOkResponse(response))
+    assert.equal(
+      error.message,
+      'Cannot fetch / (500): (Cannot read response body: chunked encoding error)',
+    )
+    assert.equal(error.statusCode, 500)
+    assert.equal(error.serverMessage, '(Cannot read response body: chunked encoding error)')
   })
 })
+
+// Note: the built-in assert.rejects() does not return the rejection (the error)
+async function assertRejects(fn) {
+  try {
+    await fn()
+  } catch (err) {
+    return err
+  }
+  throw new AssertionError('Expected promise to reject')
+}
+
+/**
+ * @param {Partial<Response>} props
+ * @returns {Response}
+ */
+function createFakeResponse(props = {}) {
+  const status = props.status ?? (props.ok ? 200 : 500)
+  const ok = props.ok ?? props.status < 400
+  return {
+    headers: new Headers(),
+    url: '/',
+    async text() {
+      return '(empty response body)'
+    },
+
+    ...props,
+
+    ok,
+    status,
+  }
+}


### PR DESCRIPTION
The initial version based on the prior work here:
- [piece-indexer/indexer/lib/http-assertions.js](https://github.com/CheckerNetwork/piece-indexer/blob/5ca50aed3f083f80494df446ad3e78018a6df0c7/indexer/lib/http-assertions.js)
- [spark-checker/lib/http-assertions.js](https://github.com/CheckerNetwork/spark-checker/blob/534adf3f83ae1cbca2272c1de481f1f6078b19d2/lib/http-assertions.js)

Quoting from README:

```js
import { assertOkResponse } from 'assert-ok-response'

const response = await fetch('https://example.com/not-found')
await assertOkResponse(response)
//
// Throws:
//
//  const err = new Error(`${errorMsg ?? `Cannot fetch ${res.url}`} (${res.status}): ${body}`)
//                ^
//
//  Error: Cannot fetch https://example.com/not-found (404): <!doctype html>
//  [...]
//  at assertOkResponse (file:///Users/bajtos/src/assert-ok-response/index.js:15:15)
//  at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
//  at async file:///Users/bajtos/src/assert-ok-response/x.js:4:1 {
//    statusCode: 404,
//    serverMessage: '<!doctype html>\n' +
//  [...]
```

Error properties:

- `statusCode` (number) - The HTTP status code of the response.
- `serverMessage` (string) - The response body returned by the server.

